### PR TITLE
fix: configure cloud-init NoCloud datasource for Proxmox static IP support

### DIFF
--- a/scripts/provisioning.sh
+++ b/scripts/provisioning.sh
@@ -14,19 +14,18 @@ export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_MODE=a
 echo ${password} | sudo -S apt-get update
 echo ${password} | sudo -SE DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
-echo ${password} | sudo -SE DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y git ansible qemu-guest-agent
+echo ${password} | sudo -SE DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y git ansible qemu-guest-agent cloud-init
 echo ${password} | sudo -S systemctl enable qemu-guest-agent
-echo "Resetting network to DHCP for cloned VMs"
-sudo tee /etc/netplan/00-installer-config.yaml > /dev/null << 'EOF'
-network:
-  version: 2
-  ethernets:
-    ens18:
-      dhcp4: true
+echo "Configuring cloud-init for Proxmox NoCloud datasource"
+echo ${password} | sudo -S tee /etc/cloud/cloud.cfg.d/99-pve.cfg > /dev/null << 'EOF'
+datasource_list: [NoCloud, ConfigDrive]
 EOF
-sudo chmod 600 /etc/netplan/00-installer-config.yaml
+# Remove baked-in static netplan so cloud-init writes network config from Proxmox ipconfig0 on clone
+echo ${password} | sudo -S rm -f /etc/netplan/00-installer-config.yaml
 rm /tmp/your-public-key-file
-echo "Cleaning the unique machine-id for dhcp"
-sudo rm -f sudo /etc/machine-id && sudo touch /etc/machine-id 
+echo "Cleaning the unique machine-id for cloned VMs"
+sudo rm -f /etc/machine-id && sudo touch /etc/machine-id
 sudo rm -f /var/lib/dbus/machine-id
 sudo ln -s /etc/machine-id /var/lib/dbus/machine-id
+echo "Resetting cloud-init state for clean first-boot on clone"
+echo ${password} | sudo -S cloud-init clean --logs


### PR DESCRIPTION
## Summary

- Installs `cloud-init` in the Packer provisioning script alongside `qemu-guest-agent`
- Configures `/etc/cloud/cloud.cfg.d/99-pve.cfg` with `datasource_list: [NoCloud, ConfigDrive]` so Proxmox's `ipconfig0` static IP is applied on first boot of every clone
- Removes the baked-in DHCP netplan (`00-installer-config.yaml`) so cloud-init can write the correct network config
- Runs `cloud-init clean --logs` before templating so every VM clone starts from a clean state
- Fixes pre-existing typo: `sudo rm -f sudo /etc/machine-id` → `sudo rm -f /etc/machine-id`

## Root cause

Proxmox writes VM network configuration (from `ipconfig0`, e.g. `ip=192.168.0.38/24,gw=192.168.0.1`) to a **NoCloud cloud-init drive** attached to each cloned VM. Without cloud-init installed and configured to read that drive, cloned VMs silently ignore the static IP and fall back to DHCP — causing the `vm-ansible-deploy` pipeline's `wait-for-ssh` step to time out waiting on an IP the VM never acquired.

**Observed symptom:** VM `my-ppm-dev` was provisioned with `ipconfig0: ip=192.168.0.38/24` but booted with `192.168.0.133` (DHCP). Pipeline failed.

## Test plan

- [ ] Trigger `ubuntu-base-image-bake` workflow with this branch
- [ ] Clone the rebuilt template in Proxmox with a static `ipconfig0` set
- [ ] Confirm VM boots at the configured static IP
- [ ] Confirm `vm-ansible-deploy` pipeline reaches `run-playbook` without `wait-for-ssh` timeout

## Related

- dante PR: bump `ubuntu-base-image-bake` default `git-branch` to `main` + increase wait-for-ssh timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)