### PR TITLE
fix: replace personal SSH key with dedicated platform ansible key

### DIFF
--- a/administrator.pub
+++ b/administrator.pub
@@ -1,1 +1,1 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILY0n5GNVfJvz307c6VvCnFx1VF3Ufh3pNvzqZd2EMQF castrobasurto.angel@gmail.com
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILR9m0M4pIY8j4kTwRRvnTa/UtUE9BncDcDEyK3+Zwxn vm-ansible-workflow@dante-platform


### PR DESCRIPTION
## Summary

- Replace the personal `castrobasurto.angel@gmail.com` key in `administrator.pub` with a dedicated `vm-ansible-workflow@dante-platform` key
- This is the key stored as the `vm-ansible-ssh-key` secret in the `argo-workflows` namespace, mounted by `vm-ansible-deploy`'s `run-playbook-step`
- Future Packer template builds will bake this key into the `administrator` user's `authorized_keys` instead of the personal key

## What changed

- `administrator.pub`: new dedicated platform ansible SSH public key

## Note

The current VM 104 (`my-ppm-dev`) already has this new key added to its `authorized_keys` manually. Future clones from the rebuilt template will have it baked in.

## Test plan

- [ ] Merge and trigger `ubuntu-base-image-bake` workflow to rebuild template
- [ ] New template clones authenticate via `vm-ansible-workflow@dante-platform` key only

🤖 Generated with [Claude Code](https://claude.com/claude-code)